### PR TITLE
allow appendTo config to be passed through

### DIFF
--- a/src/timepickerdirective.js
+++ b/src/timepickerdirective.js
@@ -52,7 +52,7 @@ angular.module('ui.timepicker', [])
                 ngModel.$render();
             }, true);
 
-            config.appendTo = element.parent();
+            config.appendTo = config.appendTo || element.parent();
 
             element.timepicker(
                 angular.extend(

--- a/src/timepickerdirective.js
+++ b/src/timepickerdirective.js
@@ -62,6 +62,10 @@ angular.module('ui.timepicker', [])
                 )
             );
 
+            element.on('$destroy', function(){
+                element.timepicker('remove');
+            });
+
             var asDate = function() {
                 var baseDate = ngModel.$modelValue ? ngModel.$modelValue : scope.baseDate;
                 return isAMoment(baseDate) ? baseDate.toDate() : baseDate;


### PR DESCRIPTION
Allows the `appendTo` config to be passed through to the jquery plugin instead of forcing it to the parent element. Also adds a destroy event to make sure the dropdown menu gets removed when the scope is destroyed (in case it was appended elsewhere).